### PR TITLE
Cpp build

### DIFF
--- a/buildtools/build.fsx
+++ b/buildtools/build.fsx
@@ -42,7 +42,8 @@ Target "GenerateSwig" (fun _ ->
     trace "running swig generation"
     let cppClientLocation = downloadCppClientIfNonexist cppClientVersion
     let swigToolPath = downloadSwigToolsIfNonexist swigVersion
-    let cppClientInclude = @"../buildtools" @@ cppClientLocation @@ "include" // remember, it's gonna run from ../swig folder
+    copyIncludeForSwig cppClientLocation "../swig/native_client/include"
+    let cppClientInclude = @"native_client/include" // remember, it's gonna run from ../swig folder
     let sourceDir = "../swig"
     let _namespace = "Infinispan.HotRod.SWIGGen"
     generateCSharpFilesFromSwigTemplates swigToolPath cppClientInclude sourceDir _namespace generateDir
@@ -52,8 +53,8 @@ Target "GenerateSwig" (fun _ ->
 Target "BuildSwigWraper" (fun _ ->
     trace "running swig wraper build"
     let cppClientLocation = downloadCppClientIfNonexist cppClientVersion
-    directoryCopy (cppClientLocation @@ "include") "../swig/include" true
-    directoryCopy (cppClientLocation @@ "lib") "../swig/native_client/lib" true
+    copyIncludeForSwig cppClientLocation "../swig/native_client/include"
+    copyLibForSwig cppClientLocation "../swig/native_client/lib"
     buildSwig ()
 )
 

--- a/buildtools/helper_functions.fsx
+++ b/buildtools/helper_functions.fsx
@@ -105,7 +105,7 @@ let unzipFile file where =
 let unzipRpmFile file where folder =
     ExecProcess (fun p ->
         p.FileName <- "bash"
-        p.Arguments <- sprintf "-c \"rpm2cpio %s | cpio -idmv\"" file
+        p.Arguments <- sprintf "-c \" mkdir -p %s && cd %s && rpm2cpio ../%s | cpio -idmv ; cd -\"" folder folder file
         p.WorkingDirectory <- where) (TimeSpan.FromMinutes 5.0) |> ignore
     
 
@@ -306,6 +306,6 @@ let buildSwig () =
     else
         let cppResult = ExecProcess (fun p ->
             p.FileName <- "g++"
-            p.Arguments <- sprintf "hotrodcs_wrap.cxx -shared -DHR_PROTO_EXPORT=\"\" -fPIC -Iinclude -Inative_client/include -o native_client/lib/hotrod_wrap.so -Lnative_client/lib -Wl,-rpath,native_client/lib -lhotrod"
+            p.Arguments <- sprintf "hotrodcs_wrap.cxx  -std=c++11 -shared -DHR_PROTO_EXPORT=\"\" -fPIC -Iinclude -Inative_client/include -o native_client/lib/hotrod_wrap.so -Lnative_client/lib -Wl,-rpath,native_client/lib -lhotrod"
             p.WorkingDirectory <- "../swig") (TimeSpan.FromMinutes 5.0)
         if cppResult <> 0 then failwith "could not process swig files"

--- a/buildtools/helper_functions.fsx
+++ b/buildtools/helper_functions.fsx
@@ -104,16 +104,8 @@ let unzipFile file where =
 ///
 let unzipRpmFile file where folder =
     ExecProcess (fun p ->
-        p.FileName <- "rpm2archive"
-        p.Arguments <- file
-        p.WorkingDirectory <- where) (TimeSpan.FromMinutes 5.0) |> ignore
-    ExecProcess (fun p ->
-        p.FileName <- "mkdir"
-        p.Arguments <- folder
-        p.WorkingDirectory <- where) (TimeSpan.FromMinutes 5.0)  |> ignore
-    ExecProcess (fun p ->
-        p.FileName <- "tar"
-        p.Arguments <- sprintf "xvf %s.%s -C %s" file "tgz" folder
+        p.FileName <- "bash"
+        p.Arguments <- sprintf "-c \"rpm2cpio %s | cpio -idmv\"" file
         p.WorkingDirectory <- where) (TimeSpan.FromMinutes 5.0) |> ignore
     
 

--- a/swig/hotrod_wrap.vcxproj
+++ b/swig/hotrod_wrap.vcxproj
@@ -20,7 +20,7 @@
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <ProjectGUID>{E6DF2B54-FBBC-394B-BDA2-7AFF50E06C51}</ProjectGUID>
-    <WindowsTargetPlatformVersion>10.0.15063.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.14393.0</WindowsTargetPlatformVersion>
     <Keyword>Win32Proj</Keyword>
     <Platform>x64</Platform>
     <ProjectName>hotrod_wrap</ProjectName>
@@ -30,25 +30,25 @@
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>MultiByte</CharacterSet>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>MultiByte</CharacterSet>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='MinSizeRel|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>MultiByte</CharacterSet>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='RelWithDebInfo|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>MultiByte</CharacterSet>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">
@@ -86,7 +86,7 @@
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
-      <AdditionalIncludeDirectories>include;include\swig;include\infinispan\hotrod;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>include;native_client\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AssemblerListingLocation>Debug/</AssemblerListingLocation>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <CompileAs>CompileAsCpp</CompileAs>
@@ -103,10 +103,10 @@
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>WIN32;_WINDOWS;_DEBUG;CMAKE_INTDIR=\"Debug\";hotrod_wrap_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>include;include\swig;include\infinispan\hotrod;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>include;native_client\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ResourceCompile>
     <Midl>
-      <AdditionalIncludeDirectories>include;include\swig;include\infinispan\hotrod;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>include;native_client\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <OutputDirectory>$(ProjectDir)/$(IntDir)</OutputDirectory>
       <HeaderFileName>%(Filename).h</HeaderFileName>
       <TypeLibraryName>%(Filename).tlb</TypeLibraryName>
@@ -131,7 +131,7 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
-      <AdditionalIncludeDirectories>include;include\swig;include\infinispan\hotrod;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>include;native_client\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AssemblerListingLocation>Release/</AssemblerListingLocation>
       <CompileAs>CompileAsCpp</CompileAs>
       <ExceptionHandling>Sync</ExceptionHandling>
@@ -148,10 +148,10 @@
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>WIN32;_WINDOWS;NDEBUG;CMAKE_INTDIR=\"Release\";hotrod_wrap_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>include;include\swig;include\infinispan\hotrod;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>include;native_client\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ResourceCompile>
     <Midl>
-      <AdditionalIncludeDirectories>include;include\swig;include\infinispan\hotrod;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>include;native_client\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <OutputDirectory>$(ProjectDir)/$(IntDir)</OutputDirectory>
       <HeaderFileName>%(Filename).h</HeaderFileName>
       <TypeLibraryName>%(Filename).tlb</TypeLibraryName>
@@ -176,7 +176,7 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='MinSizeRel|x64'">
     <ClCompile>
-      <AdditionalIncludeDirectories>include;include\swig;include\infinispan\hotrod;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>include;native_client\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AssemblerListingLocation>MinSizeRel/</AssemblerListingLocation>
       <CompileAs>CompileAsCpp</CompileAs>
       <ExceptionHandling>Sync</ExceptionHandling>
@@ -193,10 +193,10 @@
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>WIN32;_WINDOWS;NDEBUG;CMAKE_INTDIR=\"MinSizeRel\";hotrod_wrap_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>include;include\swig;include\infinispan\hotrod;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>include;native_client\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ResourceCompile>
     <Midl>
-      <AdditionalIncludeDirectories>include;include\swig;include\infinispan\hotrod;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>include;native_client\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <OutputDirectory>$(ProjectDir)/$(IntDir)</OutputDirectory>
       <HeaderFileName>%(Filename).h</HeaderFileName>
       <TypeLibraryName>%(Filename).tlb</TypeLibraryName>
@@ -221,7 +221,7 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='RelWithDebInfo|x64'">
     <ClCompile>
-      <AdditionalIncludeDirectories>include;include\swig;include\infinispan\hotrod;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>include;native_client\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AssemblerListingLocation>RelWithDebInfo/</AssemblerListingLocation>
       <CompileAs>CompileAsCpp</CompileAs>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
@@ -237,10 +237,10 @@
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>WIN32;_WINDOWS;NDEBUG;CMAKE_INTDIR=\"RelWithDebInfo\";hotrod_wrap_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>include;include\swig;include\infinispan\hotrod;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>include;native_client\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ResourceCompile>
     <Midl>
-      <AdditionalIncludeDirectories>include;include\swig;include\infinispan\hotrod;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>include;native_client\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <OutputDirectory>$(ProjectDir)/$(IntDir)</OutputDirectory>
       <HeaderFileName>%(Filename).h</HeaderFileName>
       <TypeLibraryName>%(Filename).tlb</TypeLibraryName>


### PR DESCRIPTION
Changed the way files are copied from the archive because rpm package has different dir structure from windows package.

Changed unpack of rpm so it work also on systems that hasn't rpm2archive

fixed option for g++ compiler

moved include under native_client to have all the unpacked files in the same folder